### PR TITLE
Pick a subchannel which connection is established

### DIFF
--- a/src/grpcbox_channel.erl
+++ b/src/grpcbox_channel.erl
@@ -5,6 +5,7 @@
 -export([start_link/3,
          is_ready/1,
          pick/2,
+         pick/3,
          stop/1,
          stop/2]).
 -export([init/1,
@@ -55,11 +56,19 @@ is_ready(Name) ->
     gen_statem:call(?CHANNEL(Name), is_ready).
 
 %% @doc Picks a subchannel from a pool using the configured strategy.
--spec pick(name(), unary | stream) -> {ok, {pid(), grpcbox_client:interceptor() | undefined}} |
-                                   {error, undefined_channel | no_endpoints}.
+-spec pick(name(), unary | stream) ->
+    {ok, {pid(), grpcbox_client:interceptor() | undefined}} |
+    {error, undefined_channel | no_endpoints}.
 pick(Name, CallType) ->
+    pick(Name, CallType, undefined).
+
+%% @doc Picks a subchannel from a pool using the configured strategy.
+-spec pick(name(), unary | stream, term() | undefined) ->
+    {ok, {pid(), grpcbox_client:interceptor() | undefined}} |
+    {error, undefined_channel | no_endpoints}.
+pick(Name, CallType, Key) ->
     try
-        case gproc_pool:pick_worker(Name) of
+        case pick_worker(Name, Key) of
             false -> {error, no_endpoints};
             Pid when is_pid(Pid) ->
                 {ok, {Pid, interceptor(Name, CallType)}}
@@ -68,6 +77,11 @@ pick(Name, CallType) ->
         error:badarg ->
             {error, undefined_channel}
     end.
+
+pick_worker(Name, undefined) ->
+    gproc_pool:pick_worker(Name);
+pick_worker(Name, Key) ->
+    gproc_pool:pick_worker(Name, Key).
 
 -spec interceptor(name(), unary | stream) -> grpcbox_client:interceptor() | undefined.
 interceptor(Name, CallType) ->
@@ -175,4 +189,3 @@ start_workers(Pool, StatsHandler, Encoding, Endpoints) ->
              Encoding, StatsHandler),
          Pid
      end || Endpoint={Transport, Host, Port, SSLOptions} <- Endpoints].
-

--- a/src/grpcbox_channel.erl
+++ b/src/grpcbox_channel.erl
@@ -6,6 +6,8 @@
          is_ready/1,
          pick/2,
          pick/3,
+         add_endpoints/2,
+         remove_endpoints/3,
          stop/1,
          stop/2]).
 -export([init/1,
@@ -83,6 +85,12 @@ pick_worker(Name, undefined) ->
 pick_worker(Name, Key) ->
     gproc_pool:pick_worker(Name, Key).
 
+add_endpoints(Name, Endpoints) ->
+    gen_statem:call(?CHANNEL(Name), {add_endpoints, Endpoints}).
+
+remove_endpoints(Name, Endpoints, Reason) ->
+    gen_statem:call(?CHANNEL(Name), {remove_endpoints, Endpoints, Reason}).
+
 -spec interceptor(name(), unary | stream) -> grpcbox_client:interceptor() | undefined.
 interceptor(Name, CallType) ->
     case ets:lookup(?CHANNELS_TAB, {Name, CallType}) of
@@ -112,14 +120,13 @@ init([Name, Endpoints, Options]) ->
         pool = Name,
         encoding = Encoding,
         stats_handler = StatsHandler,
-        endpoints = Endpoints
+        endpoints = lists:usort(Endpoints)
     },
-
     case maps:get(sync_start, Options, false) of
         false ->
             {ok, idle, Data, [{next_event, internal, connect}]};
         true ->
-            _ = start_workers(Name, StatsHandler, Encoding, Endpoints),
+            start_workers(Name, StatsHandler, Encoding, Endpoints),
             {ok, connected, Data}
     end.
 
@@ -128,6 +135,23 @@ callback_mode() ->
 
 connected({call, From}, is_ready, _Data) ->
     {keep_state_and_data, [{reply, From, true}]};
+connected({call, From}, {add_endpoints, Endpoints},
+            Data=#data{pool=Pool,
+                       stats_handler=StatsHandler,
+                       encoding=Encoding,
+                       endpoints=TotalEndpoints}) ->
+    NewEndpoints = lists:subtract(Endpoints, TotalEndpoints),
+    NewTotalEndpoints = lists:umerge(TotalEndpoints, Endpoints),
+    start_workers(Pool, StatsHandler, Encoding, NewEndpoints),
+    {keep_state, Data#data{endpoints=NewTotalEndpoints}, [{reply, From, ok}]};
+connected({call, From}, {remove_endpoints, Endpoints, Reason},
+            Data=#data{pool=Pool, endpoints=TotalEndpoints}) ->
+
+    NewEndpoints = sets:to_list(sets:intersection(sets:from_list(Endpoints),
+                                sets:from_list(TotalEndpoints))),
+    NewTotalEndpoints = lists:subtract(TotalEndpoints, Endpoints),
+    stop_workers(Pool, NewEndpoints, Reason),
+    {keep_state, Data#data{endpoints = NewTotalEndpoints}, [{reply, From, ok}]};
 connected(EventType, EventContent, Data) ->
     handle_event(EventType, EventContent, Data).
 
@@ -135,7 +159,8 @@ idle(internal, connect, Data=#data{pool=Pool,
                                    stats_handler=StatsHandler,
                                    encoding=Encoding,
                                    endpoints=Endpoints}) ->
-    _ = start_workers(Pool, StatsHandler, Encoding, Endpoints),
+
+    start_workers(Pool, StatsHandler, Encoding, Endpoints),
     {next_state, connected, Data};
 idle({call, From}, is_ready, _Data) ->
     {keep_state_and_data, [{reply, From, false}]};
@@ -184,8 +209,16 @@ insert_stream_interceptor(Name, _Type, Interceptors) ->
 
 start_workers(Pool, StatsHandler, Encoding, Endpoints) ->
     [begin
-         gproc_pool:add_worker(Pool, Endpoint),
-         {ok, Pid} = grpcbox_subchannel:start_link(Endpoint, Pool, {Transport, Host, Port, SSLOptions},
-             Encoding, StatsHandler),
-         Pid
-     end || Endpoint={Transport, Host, Port, SSLOptions} <- Endpoints].
+        gproc_pool:add_worker(Pool, Endpoint),
+        {ok, Pid} = grpcbox_subchannel:start_link(Endpoint,
+                                                    Pool, Endpoint, Encoding, StatsHandler),
+        Pid
+     end || Endpoint <- Endpoints].
+
+stop_workers(Pool, Endpoints, Reason) ->
+    [begin
+        case gproc_pool:whereis_worker(Pool, Endpoint) of
+            undefined -> ok;
+            Pid -> grpcbox_subchannel:stop(Pid, Reason)
+        end
+     end || Endpoint <- Endpoints].

--- a/src/grpcbox_channel.erl
+++ b/src/grpcbox_channel.erl
@@ -4,6 +4,7 @@
 
 -export([start_link/3,
          is_ready/1,
+         get/3,
          pick/2,
          pick/3,
          add_endpoints/2,
@@ -56,6 +57,16 @@ start_link(Name, Endpoints, Options) ->
 -spec is_ready(name()) -> boolean().
 is_ready(Name) ->
     gen_statem:call(?CHANNEL(Name), is_ready).
+
+-spec get(name(), unary | stream, term()) ->
+    {ok, {pid(), grpcbox_client:interceptor() | undefined}} |
+    {error, undefined_channel | not_found_endpoint}.
+get(Name, CallType, Key) ->
+    case lists:keyfind(Key, 1, gproc_pool:active_workers(Name)) of
+        {_, Pid} -> {ok, {Pid, interceptor(Name, CallType)}};
+        false -> {error, not_found_endpoint}
+    end.
+
 
 %% @doc Picks a subchannel from a pool using the configured strategy.
 -spec pick(name(), unary | stream) ->

--- a/src/grpcbox_channel.erl
+++ b/src/grpcbox_channel.erl
@@ -116,6 +116,8 @@ init([Name, Endpoints, Options]) ->
 
     gproc_pool:new(Name, BalancerType, [{size, length(Endpoints)},
                                         {auto_size, true}]),
+    gproc_pool:new({Name, active}, BalancerType, [{size, length(Endpoints)},
+                                        {auto_size, true}]),
     Data = #data{
         pool = Name,
         encoding = Encoding,
@@ -171,10 +173,12 @@ handle_event(_, _, Data) ->
     {keep_state, Data}.
 
 terminate({shutdown, force_delete}, _State, #data{pool=Name}) ->
-    gproc_pool:force_delete(Name);
+    gproc_pool:force_delete(Name),
+    gproc_pool:force_delete({Name, active});
 terminate(Reason, _State, #data{pool=Name}) ->
     [grpcbox_subchannel:stop(Pid, Reason) || {_Channel, Pid} <- gproc_pool:active_workers(Name)],
     gproc_pool:delete(Name),
+    gproc_pool:delete({Name, active}),
     ok.
 
 insert_interceptors(Name, Interceptors) ->
@@ -210,6 +214,7 @@ insert_stream_interceptor(Name, _Type, Interceptors) ->
 start_workers(Pool, StatsHandler, Encoding, Endpoints) ->
     [begin
         gproc_pool:add_worker(Pool, Endpoint),
+        gproc_pool:add_worker({Pool, active}, Endpoint),
         {ok, Pid} = grpcbox_subchannel:start_link(Endpoint,
                                                     Pool, Endpoint, Encoding, StatsHandler),
         Pid

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -47,7 +47,8 @@
 
 get_channel(Options, Type) ->
     Channel = maps:get(channel, Options, default_channel),
-    grpcbox_channel:pick(Channel, Type).
+    Key =  maps:get(key, Options, undefined),
+    grpcbox_channel:pick(Channel, Type, Key).
 
 unary(Ctx, Service, Method, Input, Def, Options) ->
     unary(Ctx, filename:join([<<>>, Service, Method]), Input, Def, Options).

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -50,6 +50,7 @@ get_channel(Options, Type) ->
     Key =  maps:get(key, Options, undefined),
     PickStrategy =  maps:get(pick_strategy, Options, undefined),
     case PickStrategy of
+        specify_worker -> grpcbox_channel:get(Channel, Type, Key);
         active_worker ->  grpcbox_channel:pick({Channel, active}, Type, Key);
         undefined -> grpcbox_channel:pick(Channel, Type, Key)
     end.

--- a/src/grpcbox_client.erl
+++ b/src/grpcbox_client.erl
@@ -48,7 +48,11 @@
 get_channel(Options, Type) ->
     Channel = maps:get(channel, Options, default_channel),
     Key =  maps:get(key, Options, undefined),
-    grpcbox_channel:pick(Channel, Type, Key).
+    PickStrategy =  maps:get(pick_strategy, Options, undefined),
+    case PickStrategy of
+        active_worker ->  grpcbox_channel:pick({Channel, active}, Type, Key);
+        undefined -> grpcbox_channel:pick(Channel, Type, Key)
+    end.
 
 unary(Ctx, Service, Method, Input, Def, Options) ->
     unary(Ctx, filename:join([<<>>, Service, Method]), Input, Def, Options).

--- a/src/grpcbox_subchannel.erl
+++ b/src/grpcbox_subchannel.erl
@@ -14,7 +14,8 @@
          ready/3,
          disconnected/3]).
 
--record(data, {endpoint :: grpcbox_channel:endpoint(),
+-record(data, {name :: any(),
+               endpoint :: grpcbox_channel:endpoint(),
                channel :: grpcbox_channel:t(),
                info :: #{authority := binary(),
                          scheme := binary(),
@@ -41,8 +42,10 @@ stop(Pid, Reason) ->
 
 init([Name, Channel, Endpoint, Encoding, StatsHandler]) ->
     process_flag(trap_exit, true),
+
     gproc_pool:connect_worker(Channel, Name),
-    {ok, disconnected, #data{conn=undefined,
+    {ok, disconnected, #data{name=Name,
+                             conn=undefined,
                              info=info_map(Endpoint, Encoding, StatsHandler),
                              endpoint=Endpoint,
                              channel=Channel}}.
@@ -89,24 +92,24 @@ handle_event(_, _, _) ->
     keep_state_and_data.
 
 terminate(_Reason, _State, #data{conn=undefined,
-                                 endpoint=Endpoint,
+                                 name=Name,
                                  channel=Channel}) ->
-    gproc_pool:disconnect_worker(Channel, Endpoint),
-    gproc_pool:remove_worker(Channel, Endpoint),
+    gproc_pool:disconnect_worker(Channel, Name),
+    gproc_pool:remove_worker(Channel, Name),
     ok;
 terminate(normal, _State, #data{conn=Pid,
-                                 endpoint=Endpoint,
+                                 name=Name,
                                  channel=Channel}) ->
     h2_connection:stop(Pid),
-    gproc_pool:disconnect_worker(Channel, Endpoint),
-    gproc_pool:remove_worker(Channel, Endpoint),
+    gproc_pool:disconnect_worker(Channel, Name),
+    gproc_pool:remove_worker(Channel, Name),
     ok;
 terminate(Reason, _State, #data{conn=Pid,
-                                 endpoint=Endpoint,
+                                 name=Name,
                                  channel=Channel}) ->
+    gproc_pool:disconnect_worker(Channel, Name),
+    gproc_pool:remove_worker(Channel, Name),
     exit(Pid, Reason),
-    gproc_pool:disconnect_worker(Channel, Endpoint),
-    gproc_pool:remove_worker(Channel, Endpoint),
     ok.
 
 connect(Data=#data{conn=undefined,

--- a/test/grpcbox_SUITE.erl
+++ b/test/grpcbox_SUITE.erl
@@ -331,6 +331,7 @@ end_per_testcase(_, _Config) ->
 initially_down_service(_Config) ->
     Point = #{latitude => 409146138, longitude => -746188906},
     Ctx = ctx:with_deadline_after(ctx:new(), 5, second),
+    ct:sleep(100),
     ?assertMatch({error, econnrefused}, routeguide_route_guide_client:get_feature(Ctx, Point)),
 
     grpcbox:start_server(#{grpc_opts => #{service_protos => [route_guide_pb],

--- a/test/grpcbox_channel_SUITE.erl
+++ b/test/grpcbox_channel_SUITE.erl
@@ -6,7 +6,8 @@
         add_and_remove_endpoints/1,
         add_and_remove_endpoints_active_workers/1,
         pick_worker_strategy/1,
-        pick_active_worker_strategy/1]).
+        pick_active_worker_strategy/1,
+        pick_specify_worker_strategy/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -15,7 +16,8 @@ all() ->
         add_and_remove_endpoints,
         add_and_remove_endpoints_active_workers,
         pick_worker_strategy,
-        pick_active_worker_strategy
+        pick_active_worker_strategy,
+        pick_specify_worker_strategy
     ].
 init_per_suite(_Config) ->
     application:set_env(grpcbox, client, #{channel => []}),
@@ -96,6 +98,13 @@ pick_active_worker_strategy(_Config) ->
     ?assertEqual(error, pick_worker({direct_channel, active})),
     ?assertEqual(error, pick_worker({hash_channel, active})),
     ok.
+
+pick_specify_worker_strategy(_Config) ->
+    ?assertMatch({ok, _} ,grpcbox_channel:get(default_channel, stream, {http, "127.0.0.1", 18080, #{}})),
+    ?assertEqual({error, not_found_endpoint} ,grpcbox_channel:get(default_channel, stream, {http, "127.0.0.1", 8080, #{}})),
+    ?assertEqual({error, not_found_endpoint} ,grpcbox_channel:get(channel_xxx, stream, {http, "127.0.0.1", 8080, #{}})),
+    ok.
+
 pick_worker(Name, N) ->
     {R, _} = grpcbox_channel:pick(Name, unary, N),
     R.

--- a/test/grpcbox_channel_SUITE.erl
+++ b/test/grpcbox_channel_SUITE.erl
@@ -4,27 +4,43 @@
         init_per_suite/1,
         end_per_suite/1,
         add_and_remove_endpoints/1,
-        pick_worker_strategy/1]).
+        add_and_remove_endpoints_active_workers/1,
+        pick_worker_strategy/1,
+        pick_active_worker_strategy/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
     [
-        add_and_remove_endpoints
+        add_and_remove_endpoints,
+        add_and_remove_endpoints_active_workers,
+        pick_worker_strategy,
+        pick_active_worker_strategy
     ].
 init_per_suite(_Config) ->
-    application:set_env(grpcbox, servers, []),
+    application:set_env(grpcbox, client, #{channel => []}),
+    GrpcOptions = #{service_protos => [route_guide_pb], services => #{'routeguide.RouteGuide' => routeguide_route_guide}},
+    Servers = [#{grpc_opts => GrpcOptions,
+                 listen_opts => #{port => 18080, ip => {127,0,0,1}}},
+                #{grpc_opts => GrpcOptions,
+                 listen_opts => #{port => 18081, ip => {127,0,0,1}}},
+                 #{grpc_opts => GrpcOptions,
+                 listen_opts => #{port => 18082, ip => {127,0,0,1}}},
+                 #{grpc_opts => GrpcOptions,
+                 listen_opts => #{port => 18083, ip => {127,0,0,1}}}],
+    application:set_env(grpcbox, servers, Servers),
     application:ensure_all_started(grpcbox),
+    ct:sleep(1000),
     grpcbox_channel_sup:start_link(),
-    grpcbox_channel_sup:start_child(default_channel, [{https, "127.0.0.1", 8080, #{}}], #{}),
+    grpcbox_channel_sup:start_child(default_channel, [{http, "127.0.0.1", 18080, #{}}], #{}),
     grpcbox_channel_sup:start_child(random_channel,
-                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    [{http, "127.0.0.1", 18080, #{}}, {http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}],
                                     #{balancer => random}),
     grpcbox_channel_sup:start_child(hash_channel,
-                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    [{http, "127.0.0.1", 18080, #{}}, {http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}],
                                     #{balancer => hash}),
     grpcbox_channel_sup:start_child(direct_channel,
-                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    [{http, "127.0.0.1", 18080, #{}}, {http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.4", 18084, #{}}],
                                     #{ balancer => direct}),
 
     _Config.
@@ -33,8 +49,56 @@ end_per_suite(_Config) ->
     application:stop(grpcbox),
     ok.
 
+
 add_and_remove_endpoints(_Config) ->
-    grpcbox_channel:add_endpoints(default_channel, [{https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}]),
-    ?assertMatch(4, length(gproc_pool:active_workers(default_channel))),
-    grpcbox_channel:remove_endpoints(default_channel, [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}], normal),
-    ?assertMatch(1, length(gproc_pool:active_workers(default_channel))).
+    grpcbox_channel:add_endpoints(default_channel, [{http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}]),
+    ?assertEqual(4, length(gproc_pool:active_workers(default_channel))),
+    grpcbox_channel:add_endpoints(default_channel, [{https, "127.0.0.1", 18081, #{}}, {https, "127.0.0.1", 18082, #{}}, {https, "127.0.0.1", 18083, #{}}]),
+    ?assertEqual(7, length(gproc_pool:active_workers(default_channel))),
+    grpcbox_channel:remove_endpoints(default_channel, [{http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}], normal),
+    ?assertEqual(4, length(gproc_pool:active_workers(default_channel))),
+    grpcbox_channel:remove_endpoints(default_channel, [{https, "127.0.0.1", 18080, #{}}, {https, "127.0.0.1", 18081, #{}}, {https, "127.0.0.1", 18082, #{}}], normal),
+    ?assertEqual(2, length(gproc_pool:active_workers(default_channel))).
+
+add_and_remove_endpoints_active_workers(_Config) ->
+    grpcbox_channel:add_endpoints(default_channel, [{http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}]),
+    ct:sleep(1000),
+    ?assertEqual(4, length(gproc_pool:active_workers({default_channel, active}))),
+    grpcbox_channel:add_endpoints(default_channel, [{https, "127.0.0.1", 18081, #{}}, {https, "127.0.0.1", 18082, #{}}, {https, "127.0.0.1", 18083, #{}}]),
+    ct:sleep(1000),
+    ?assertEqual(4, length(gproc_pool:active_workers({default_channel, active}))),
+    grpcbox_channel:remove_endpoints(default_channel, [{http, "127.0.0.1", 18081, #{}}, {http, "127.0.0.1", 18082, #{}}, {http, "127.0.0.1", 18083, #{}}], normal),
+    ct:sleep(1000),
+    ?assertEqual(1, length(gproc_pool:active_workers({default_channel, active}))),
+    grpcbox_channel:remove_endpoints(default_channel, [{https, "127.0.0.1", 18081, #{}}, {https, "127.0.0.1", 18082, #{}}, {https, "127.0.0.1", 18083, #{}}], normal),
+    ct:sleep(1000),
+    ?assertEqual(1, length(gproc_pool:active_workers({default_channel, active}))).
+
+pick_worker_strategy(_Config) ->
+    ?assertEqual(ok, pick_worker(default_channel)),
+    ?assertEqual(ok, pick_worker(random_channel)),
+    ?assertEqual(ok, pick_worker(direct_channel, 1)),
+    ?assertEqual(ok, pick_worker(hash_channel, 1)),
+    ?assertEqual(error, pick_worker(default_channel, 1)),
+    ?assertEqual(error, pick_worker(random_channel, 1)),
+    ?assertEqual(error, pick_worker(direct_channel)),
+    ?assertEqual(error, pick_worker(hash_channel)),
+    ok.
+
+pick_active_worker_strategy(_Config) ->
+    ct:sleep(1000),
+    ?assertEqual(ok, pick_worker({default_channel, active})),
+    ?assertEqual(ok, pick_worker({random_channel, active})),
+    ?assertEqual(ok, pick_worker({direct_channel, active}, 1)),
+    ?assertEqual(ok, pick_worker({hash_channel, active}, 1)),
+    ?assertEqual(error, pick_worker({default_channel, active}, 1)),
+    ?assertEqual(error, pick_worker({random_channel, active}, 1)),
+    ?assertEqual(error, pick_worker({direct_channel, active})),
+    ?assertEqual(error, pick_worker({hash_channel, active})),
+    ok.
+pick_worker(Name, N) ->
+    {R, _} = grpcbox_channel:pick(Name, unary, N),
+    R.
+pick_worker(Name) ->
+    {R, _} = grpcbox_channel:pick(Name, unary, undefined),
+    R.

--- a/test/grpcbox_channel_SUITE.erl
+++ b/test/grpcbox_channel_SUITE.erl
@@ -1,0 +1,40 @@
+-module(grpcbox_channel_SUITE).
+
+-export([all/0,
+        init_per_suite/1,
+        end_per_suite/1,
+        add_and_remove_endpoints/1,
+        pick_worker_strategy/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [
+        add_and_remove_endpoints
+    ].
+init_per_suite(_Config) ->
+    application:set_env(grpcbox, servers, []),
+    application:ensure_all_started(grpcbox),
+    grpcbox_channel_sup:start_link(),
+    grpcbox_channel_sup:start_child(default_channel, [{https, "127.0.0.1", 8080, #{}}], #{}),
+    grpcbox_channel_sup:start_child(random_channel,
+                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    #{balancer => random}),
+    grpcbox_channel_sup:start_child(hash_channel,
+                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    #{balancer => hash}),
+    grpcbox_channel_sup:start_child(direct_channel,
+                                    [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}],
+                                    #{ balancer => direct}),
+
+    _Config.
+
+end_per_suite(_Config) ->
+    application:stop(grpcbox),
+    ok.
+
+add_and_remove_endpoints(_Config) ->
+    grpcbox_channel:add_endpoints(default_channel, [{https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.3", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}]),
+    ?assertMatch(4, length(gproc_pool:active_workers(default_channel))),
+    grpcbox_channel:remove_endpoints(default_channel, [{https, "127.0.0.1", 8080, #{}}, {https, "127.0.0.2", 8080, #{}}, {https, "127.0.0.4", 8080, #{}}], normal),
+    ?assertMatch(1, length(gproc_pool:active_workers(default_channel))).


### PR DESCRIPTION
## Background

- In gRPC, service discovery is usually dynamic, which means that the client needs to discover the available service instances at runtime. Also, service instances may become unavailable or fail due to various reasons, such as network issues or server failures. Therefore, the client needs to use a load balancing mechanism to distribute requests to only the available and healthy service instances.
- When a gRPC client sends a request, it needs to pick a channel (i.e., a connection to a service instance) to send the request over. The channel should be available, meaning that it has an established HTTP/2 connection with a healthy service instance. The client can use various load balancing policies, such as round-robin, weighted, or locality-based, to pick the best channel for each request.
- To ensure that the client picks only the available channels, gRPC provides health checking mechanisms that allow the client to periodically check the health of the service instances. If a service instance becomes unhealthy, the client should exclude it from the list of available instances until it becomes healthy again.
- Overall, gRPC provides various mechanisms and policies to ensure that clients pick only the available and healthy channels for their requests. By using these mechanisms, clients can improve the reliability and resilience of their applications, even when service instances fail or become unavailable.


## Pick a subchannel which connection is established
- When a grpcbox_channel adds a grpcbox_subchannel, the grpcbox_subchannel will try to establish an HTTP/2 connection.
- If the HTTP/2 connection is successfully established, the grpcbox_subchannel will add itself to the {channel, active} pool. If the HTTP/2 connection is not successfully established, the grpcbox_subchannel will retry establishing the connection at a specified interval.
- The grpcbox_subchannel will check the HTTP/2 connection status by itself, and if it detects a disconnection, it will remove itself from the {channel, active} pool.
- When an application needs to choose a connected grpcbox_subchannel with an established HTTP/2 connection, it can select an available grpcbox_subchannel from the {channel, active} pool.
- When a grpcbox_subchannel is no longer needed, it should be removed from the {channel, active} pool.